### PR TITLE
Add upcoming movies, streaming providers and rating support

### DIFF
--- a/MovieSearchApp/index.html
+++ b/MovieSearchApp/index.html
@@ -12,6 +12,7 @@
         <h1 class="title">Popcorn Radar</h1>
         <div class="button-group">
             <button onclick="navigateTo('search')">🔍 Search Movies</button>
+            <button onclick="navigateTo('upcoming')">🎬 Upcoming Movies</button>
             <button onclick="navigateTo('my-list')">📋 My List</button>
         </div>
     </div>
@@ -26,7 +27,16 @@
     <div id="my-list-page" class="container hidden">
         <button class="back-button" onclick="navigateTo('home')">🏠 Back to Home</button>
         <h2>📋 My List</h2>
-        <div id="my-list" class="movies-list"></div>
+        <h3>To-Watch🔭</h3>
+        <div id="to-watch" class="movies-list"></div>
+        <h3>Favorites❤️</h3>
+        <div id="favorites" class="movies-list"></div>
+    </div>
+
+    <div id="upcoming-page" class="container hidden">
+        <button class="back-button" onclick="navigateTo('home')">🏠 Back to Home</button>
+        <h1>Upcoming Movies</h1>
+        <div id="upcoming-movies" class="movies-list"></div>
     </div>
     
     <script src="script.js"></script>

--- a/MovieSearchApp/script.js
+++ b/MovieSearchApp/script.js
@@ -2,6 +2,9 @@
 const API_KEY = '208efbe611ddf35d1e791a016487f9a4'; // Your TMDB API Key
 const API_URL = `https://api.themoviedb.org/3/search/movie?api_key=${API_KEY}&query=`;
 const MOVIE_DETAILS_URL = `https://api.themoviedb.org/3/movie/`;
+const UPCOMING_URL = `https://api.themoviedb.org/3/movie/upcoming?api_key=${API_KEY}`;
+
+let ratings = JSON.parse(localStorage.getItem('ratings')) || {};
 
 let myList = JSON.parse(localStorage.getItem('myList')) || [];
 
@@ -32,6 +35,76 @@ async function fetchMovieDetails(movieId) {
     }
 }
 
+async function fetchWatchProviders(movieId) {
+    try {
+        const response = await fetch(`${MOVIE_DETAILS_URL}${movieId}/watch/providers?api_key=${API_KEY}`);
+        const data = await response.json();
+        const us = data.results?.US;
+        if (us && us.flatrate) {
+            return us.flatrate.map(p => p.provider_name);
+        }
+        return [];
+    } catch (error) {
+        console.error('Error fetching watch providers:', error);
+        return [];
+    }
+}
+
+async function fetchUpcomingMovies() {
+    try {
+        const response = await fetch(UPCOMING_URL);
+        const data = await response.json();
+        displayUpcomingMovies(data.results);
+    } catch (error) {
+        console.error('Error fetching upcoming movies:', error);
+    }
+}
+
+async function displayUpcomingMovies(movies) {
+    const container = document.getElementById('upcoming-movies');
+    container.innerHTML = '';
+
+    if (!movies || movies.length === 0) {
+        container.innerHTML = '<p>No upcoming movies.</p>';
+        return;
+    }
+
+    for (const movie of movies) {
+        const movieDetails = await fetchMovieDetails(movie.id);
+        const providers = await fetchWatchProviders(movie.id);
+
+        const director = movieDetails?.credits?.crew?.find(person => person.job === 'Director')?.name || 'Unknown';
+        const description = movieDetails?.overview || 'No description available.';
+        const ratingValue = ratings[movie.id] || '';
+        const providerText = providers.length ? `Available on: ${providers.join(', ')}` : '';
+
+        const movieCard = document.createElement('div');
+        movieCard.classList.add('movie-card');
+        movieCard.innerHTML = `
+            <img src="https://image.tmdb.org/t/p/w500${movie.poster_path}" alt="${movie.title}">
+            <div class="movie-info">
+                <h3>${movie.title}</h3>
+                <span>📅 ${movie.release_date || 'Unknown'}</span>
+                <span>🎬 Director: ${director}</span>
+                <p>${description}</p>
+                <span class="providers">${providerText}</span>
+                <label>Your Rating:
+                    <select onchange="rateMovie(${movie.id}, this.value)">
+                        <option value="" ${ratingValue===''?'selected':''}>--</option>
+                        <option value="1" ${ratingValue===1?'selected':''}>1</option>
+                        <option value="2" ${ratingValue===2?'selected':''}>2</option>
+                        <option value="3" ${ratingValue===3?'selected':''}>3</option>
+                        <option value="4" ${ratingValue===4?'selected':''}>4</option>
+                        <option value="5" ${ratingValue===5?'selected':''}>5</option>
+                    </select>
+                </label>
+                <button onclick="addToMyList(${movie.id}, '${movie.title}', '${movie.poster_path}')">➕ Add to My List</button>
+            </div>
+        `;
+        container.appendChild(movieCard);
+    }
+}
+
 async function displayMovies(movies) {
     const moviesList = document.getElementById('movies');
     moviesList.innerHTML = '';
@@ -43,13 +116,16 @@ async function displayMovies(movies) {
 
     for (const movie of movies) {
         const movieDetails = await fetchMovieDetails(movie.id);
-        
+        const providers = await fetchWatchProviders(movie.id);
+
         const director = movieDetails?.credits?.crew?.find(person => person.job === 'Director')?.name || 'Unknown';
         const description = movieDetails?.overview || 'No description available.';
-        
+        const ratingValue = ratings[movie.id] || '';
+        const providerText = providers.length ? `Available on: ${providers.join(', ')}` : '';
+
         const movieCard = document.createElement('div');
         movieCard.classList.add('movie-card');
-        
+
         movieCard.innerHTML = `
             <img src="https://image.tmdb.org/t/p/w500${movie.poster_path}" alt="${movie.title}">
             <div class="movie-info">
@@ -57,6 +133,17 @@ async function displayMovies(movies) {
                 <span>📅 ${movie.release_date || 'Unknown'}</span>
                 <span>🎬 Director: ${director}</span>
                 <p>${description}</p>
+                <span class="providers">${providerText}</span>
+                <label>Your Rating:
+                    <select onchange="rateMovie(${movie.id}, this.value)">
+                        <option value="" ${ratingValue===''?'selected':''}>--</option>
+                        <option value="1" ${ratingValue===1?'selected':''}>1</option>
+                        <option value="2" ${ratingValue===2?'selected':''}>2</option>
+                        <option value="3" ${ratingValue===3?'selected':''}>3</option>
+                        <option value="4" ${ratingValue===4?'selected':''}>4</option>
+                        <option value="5" ${ratingValue===5?'selected':''}>5</option>
+                    </select>
+                </label>
                 <button onclick="addToMyList(${movie.id}, '${movie.title}', '${movie.poster_path}')">➕ Add to My List</button>
             </div>
         `;
@@ -67,7 +154,7 @@ async function displayMovies(movies) {
 
 function addToMyList(id, title, poster) {
     if (!myList.some(movie => movie.id === id)) {
-        myList.push({ id, title, poster });
+        myList.push({ id, title, poster, isFavorite: false });
         localStorage.setItem('myList', JSON.stringify(myList));
         alert(`${title} added to My List!`);
     } else {
@@ -76,27 +163,43 @@ function addToMyList(id, title, poster) {
 }
 
 function displayMyList() {
-    const myListContainer = document.getElementById('my-list');
-    myListContainer.innerHTML = '';
-    
+    const watchContainer = document.getElementById('to-watch');
+    const favoriteContainer = document.getElementById('favorites');
+    watchContainer.innerHTML = '';
+    favoriteContainer.innerHTML = '';
+
     if (myList.length === 0) {
-        myListContainer.innerHTML = '<p>Your list is empty.</p>';
+        watchContainer.innerHTML = '<p>Your list is empty.</p>';
+        favoriteContainer.innerHTML = '';
         return;
     }
 
     myList.forEach(movie => {
+        const container = movie.isFavorite ? favoriteContainer : watchContainer;
+        const ratingValue = ratings[movie.id] || '';
         const movieItem = document.createElement('div');
         movieItem.classList.add('movie-card');
-        
+
         movieItem.innerHTML = `
             <img src="https://image.tmdb.org/t/p/w500${movie.poster}" alt="${movie.title}">
             <div class="movie-info">
                 <h3>${movie.title}</h3>
+                <label>Your Rating:
+                    <select onchange="rateMovie(${movie.id}, this.value)">
+                        <option value="" ${ratingValue===''?'selected':''}>--</option>
+                        <option value="1" ${ratingValue===1?'selected':''}>1</option>
+                        <option value="2" ${ratingValue===2?'selected':''}>2</option>
+                        <option value="3" ${ratingValue===3?'selected':''}>3</option>
+                        <option value="4" ${ratingValue===4?'selected':''}>4</option>
+                        <option value="5" ${ratingValue===5?'selected':''}>5</option>
+                    </select>
+                </label>
+                <button onclick="toggleFavorite(${movie.id})">${movie.isFavorite ? '💔 Unfavorite' : '❤️ Favorite'}</button>
                 <button onclick="removeFromMyList(${movie.id})">❌ Remove</button>
             </div>
         `;
-        
-        myListContainer.appendChild(movieItem);
+
+        container.appendChild(movieItem);
     });
 }
 
@@ -106,16 +209,38 @@ function removeFromMyList(id) {
     displayMyList();
 }
 
+function toggleFavorite(id) {
+    const movie = myList.find(m => m.id === id);
+    if (movie) {
+        movie.isFavorite = !movie.isFavorite;
+        localStorage.setItem('myList', JSON.stringify(myList));
+        displayMyList();
+    }
+}
+
+function rateMovie(id, rating) {
+    if (rating) {
+        ratings[id] = Number(rating);
+    } else {
+        delete ratings[id];
+    }
+    localStorage.setItem('ratings', JSON.stringify(ratings));
+}
+
 function navigateTo(page) {
     document.getElementById('start-page').classList.add('hidden');
     document.getElementById('search-page').classList.add('hidden');
     document.getElementById('my-list-page').classList.add('hidden');
-    
+    document.getElementById('upcoming-page').classList.add('hidden');
+
     if (page === 'search') {
         document.getElementById('search-page').classList.remove('hidden');
     } else if (page === 'my-list') {
         document.getElementById('my-list-page').classList.remove('hidden');
         displayMyList();
+    } else if (page === 'upcoming') {
+        document.getElementById('upcoming-page').classList.remove('hidden');
+        fetchUpcomingMovies();
     } else {
         document.getElementById('start-page').classList.remove('hidden');
     }

--- a/MovieSearchApp/style.css
+++ b/MovieSearchApp/style.css
@@ -121,3 +121,15 @@ button:hover {
     margin: 5px 0 0;
     color: #bbb;
 }
+
+.providers {
+    font-size: 12px;
+    color: #66bb6a;
+    margin-bottom: 5px;
+}
+
+.movie-info select {
+    margin: 5px 0;
+    padding: 4px;
+    border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- add new buttons and pages for upcoming movies and list categories
- support per-movie favorites and rating storage
- show streaming provider info from TMDB
- style rating select and provider label

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6843549791dc8331a95c53765e2d895b